### PR TITLE
Stringify values on upload, parse on download

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const {
     transformJsonConfigToFirebaseArgs,
     pickSameKeys,
     sortObject,
+    parseConfigValues,
 } = require('./util')
 
 const program = new commander.Command();
@@ -59,6 +60,8 @@ async function get() {
         if (program.sort) {
             config = sortObject(config)
         }
+
+        config = parseConfigValues(config)
 
         await writeJsonFile(configFile, config)
 

--- a/util.js
+++ b/util.js
@@ -14,9 +14,34 @@ exports.writeJsonFile = function writeJsonFile(filePath, jsonData) {
     return write(filePath, string + '\n')
 }
 
+function mapObject(obj, mapper) {
+    if (!obj || typeof obj !== 'object') return obj
+    return Object.entries(obj).reduce((acc, [key, value]) => ({
+        ...acc,
+        [key]: mapper(value)
+    }), {})
+}
+
+exports.parseConfigValues = function parseConfigValues(config) {
+    return mapObject(
+        config,
+        (serviceConfig) => mapObject(serviceConfig, value => {
+            try {
+                return JSON.parse(value)
+            } catch (error) {
+                return value
+            }
+        })
+    )
+}
+
+function stringifyNonStrings(value) {
+    return (typeof value === 'string') ? value : JSON.stringify(value)
+}
+
 exports.transformJsonConfigToFirebaseArgs = function transformJsonConfigToFirebaseArgs(config) {
     return Object.keys(config)
-        .map(service => Object.keys(config[service]).map(varName => `${service}.${varName}=${config[service][varName]}`))
+        .map(service => Object.keys(config[service]).map(varName => `${service}.${varName}=${stringifyNonStrings(config[service][varName])}`))
         .reduce((a, b) => [...a, ...b])
 }
 


### PR DESCRIPTION
This allows using arrays and objects in your local env files.
When uploading to Firebase, the values are stringified as Firebase expects.

Fixes #1 

So, you no longer need to do this in your `.env` file:
```
{
   "cors": {
      "whitelist": "[\"https://*.example.com\",\"https://*.anotherexample.com\"]"
  }
}
```

You can do this instead!
```
{
   "cors": {
      "whitelist": [
        "https://*.example.com",
        "https://*.anotherexample.com"
      ]
  }
}
```