### PR TITLE
Add --no-parsing option: do not parse config values when saving to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,6 @@ firebase-config-sync get
 -q, --quiet             Disable all logging
 -i, --ignore            Don't save properties that don't already exist in local file
 -s, --sort              Sort config alphabetically before saving to config file
+-n, --no-parsing        Do not parse config values before saving to file
 -f, --file <path>       Custom file to save to, if you don't want to use the one specified in configFiles
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,9 @@ async function get() {
             config = sortObject(config)
         }
 
-        const localConfig: ConfigFileLocal = parseConfigValues(config)
+        const localConfig: ConfigFileLocal = program.parsing
+            ? parseConfigValues(config)
+            : config
 
         await writeJsonFile(configFile, localConfig)
 
@@ -121,6 +123,10 @@ program
     .option(
         '-f, --file <path>',
         "get: custom file to save to, if you don't want to use the one specified in configFiles",
+    )
+    .option(
+        '-n, --no-parsing',
+        'get: do not parse config values before saving to file',
     )
     .action((cmd) => {
         command = cmd


### PR DESCRIPTION
If you're downloading to `.runtimeconfig.json`, you don't want to parse arrays and objects, you'd like to keep the config file like Firebase expects it. This change adds the `--no-parsing` option which allows you to skip the parsing process.